### PR TITLE
Added support for envers and annotation configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,13 @@
 
         <dependency>
             <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers</artifactId>
+            <version>4.0.1.Final</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
             <version>4.0.1.Final</version>
             <scope>provided</scope>


### PR DESCRIPTION
I propose adding envers support and AnnotationConfiguration support. Envers and annotation strategy could be configured in user's pom.xml as:

```
        <plugin>
            <groupId>de.akquinet.maven</groupId>
            <artifactId>hibernate4-maven-plugin</artifactId>
            <version>0.3-SNAPSHOT</version>
            <configuration>
                <configurationStrategy>ANNOTATION</configurationStrategy>
            </configuration>
            <dependencies>
                <dependency>
                    <groupId>org.hibernate</groupId>
                    <artifactId>hibernate-core</artifactId>
                    <version>${hibernate.version}</version>
                </dependency>
                <dependency>
                    <groupId>org.hibernate</groupId>
                    <artifactId>hibernate-envers</artifactId>
                    <version>${hibernate.version}</version>
                </dependency>
            </dependencies>
        </plugin>
```

Envers dependency is optional.
